### PR TITLE
pure_install action

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,6 +7,8 @@ copyright_year   = 2011
 
 ;Building
 [@LEONT]
+; List explicitely for 'dzil authodeps'
+;authordep Dist::Zilla::Plugin::BuildSelf
 install_tool = self
 BuildSelf.auto_configure_requires = 1
 AutoPrereqs.skip = File::ShareDir

--- a/lib/Module/Build/Tiny.pm
+++ b/lib/Module/Build/Tiny.pm
@@ -119,6 +119,9 @@ my %actions = (
 	},
 );
 
+# Aliasing pure_install to install
+$actions{'pure_install'} = $actions{'install'};
+
 sub Build {
 	my $action = @ARGV && $ARGV[0] =~ /\A\w+\z/ ? shift @ARGV : 'build';
 	die "No such action '$action'\n" if not $actions{$action};


### PR DESCRIPTION
2 commits:
- one that fixes the build for contributors (please cherry-pick it even if you don't want of the other feature).
- one that adds a `pure_install` action, as an alias to `install`.
