### PR TITLE
fix tests that break when PERL_INSTALL_QUIET=1 (RT#97464)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Module::Build::Tiny
 
 {{$NEXT}}
+          Fix tests which broke with ExtUtils::Install 1.68 and
+          PERL_INSTALL_QUIET=1 (RT#97464, Karen Etheridge)
 
 0.036     2014-05-02 14:51:02CEST+0200 Europe/Amsterdam
           Add --jobs argument to MBT

--- a/t/simple.t
+++ b/t/simple.t
@@ -77,6 +77,9 @@ sub _slurp { do { local (@ARGV,$/)=$_[0]; <> } }
 #--------------------------------------------------------------------------#
 
 {
+  # ExtUtils::Install 1.68 added PERL_INSTALL_QUIET, which suppresses the
+  # output we are testing for
+  local $ENV{PERL_INSTALL_QUIET};
   ok( open2(my($in, $out), $^X, 'Build'), 'Could run Build' );
   my $output = do { local $/; <$in> };
   like( $output, qr{lib/Foo/Bar\.pm}, 'Build output looks correctly');


### PR DESCRIPTION
Fix for https://rt.cpan.org/Ticket/Display.html?id=97464
