### PR TITLE
Pass basename as its args to *.PL files

### DIFF
--- a/lib/Module/Build/Tiny.pm
+++ b/lib/Module/Build/Tiny.pm
@@ -81,7 +81,10 @@ sub find {
 my %actions = (
 	build => sub {
 		my %opt = @_;
-		system $^X, $_ and die "$_ returned $?\n" for find(qr/\.PL$/, 'lib');
+		for my $pl_file (find(qr/\.PL$/, 'lib')) {
+                       (my $pm = $pl_file) =~ s/\.PL$//;
+			system $^X, $pl_file, $pm and die "$pl_file returned $?\n";
+		}
 		my %modules = map { $_ => catfile('blib', $_) } find(qr/\.p(?:m|od)$/, 'lib');
 		my %scripts = map { $_ => catfile('blib', $_) } find(qr//, 'script');
 		my %shared  = map { $_ => catfile(qw/blib lib auto share dist/, $opt{meta}->name, abs2rel($_, 'share')) } find(qr//, 'share');


### PR DESCRIPTION
This makes the *.PL invocation compatible to what MakeMaker and Module::Build does.
via https://github.com/tokuhirom/Minilla/issues/142#issuecomment-58755948
