### PR TITLE
Include ./inc/build.pl for extensibility

### DIFF
--- a/lib/Module/Build/Tiny.pm
+++ b/lib/Module/Build/Tiny.pm
@@ -61,12 +61,13 @@ sub process_xs {
 	my $version = $options->{meta}->version;
 	require ExtUtils::CBuilder;
 	my $builder = ExtUtils::CBuilder->new(config => $options->{config}->values_set);
-	my @objects = $builder->compile(source => $c_file, defines => { VERSION => qq/"$version"/, XS_VERSION => qq/"$version"/ }, include_dirs => [ curdir, 'include', dirname($source) ]);
+	my @compile_args = (include_dirs => [ curdir, 'include', dirname($source) ], extra_compiler_flags => $options->{extra_compiler_flags});
+	my @objects = $builder->compile(source => $c_file, defines => { VERSION => qq/"$version"/, XS_VERSION => qq/"$version"/ }, @compile_args);
 
 	my $o = $options->{config}->get('_o');
 	for my $c_source (@{ $c_files }) {
 		my $o_file = catfile($tempdir, basename($c_source, '.c') . $o);
-		push @objects, $builder->compile(source => $c_source, include_dirs => [ curdir, 'include', dirname($source) ])
+		push @objects, $builder->compile(source => $c_source, @compile_args);
 	}
 
 	require DynaLoader;
@@ -74,7 +75,7 @@ sub process_xs {
 
 	mkpath($archdir, $options->{verbose}, oct '755') unless -d $archdir;
 	my $lib_file = catfile($archdir, $mod2fname->(\@parts) . '.' . $options->{config}->get('dlext'));
-	return $builder->link(objects => \@objects, lib_file => $lib_file, module_name => join '::', @parts);
+	return $builder->link(objects => \@objects, lib_file => $lib_file, extra_linker_flags => $options->{extra_linker_flags}, module_name => join '::', @parts);
 }
 
 sub find {

--- a/t/simple.t
+++ b/t/simple.t
@@ -53,6 +53,9 @@ if ($has_compiler) {
 			return "Hello World!\n";
 		}
 		---
+	$dist->add_file('inc/build.pl', undent(<<'		---'));
+		return { before_copy => sub { mkdir "lib/Foo/Bar/"; open my $fh, ">", "lib/Foo/Bar/More.pm" } };
+		---
 }
 
 $dist->regen;
@@ -121,6 +124,9 @@ sub _slurp { do { local (@ARGV,$/)=$_[0]; <> } }
     my $line = <$fh>;
     like( $line, qr{\A$interpreter}, "blib/script/simple has shebang line with \$^X" );
   }
+
+  diag `find blib -type f`;
+  ok( -f 'blib/lib/' . _mod2pm( "$dist->{name}::More"), "$dist->{name}::More copied to blib" );
 
   require blib;
   blib->import;


### PR DESCRIPTION
This is a simple mechanism for extending Module::Build::Tiny. It will `do` the file `inc/build.pl`, which should return a hash that may contain the following callbacks that will all be passed the option hash:

* `expand_opts`
  This returns the new option hash. This may overwrite any of the existing values, as well as the new entries for `extra_compiler_flags` and `extra_linker_flags`.
* `before_copy`
  This is called in the build action before the pm files are copied and xs files are compiled.
* `after_copy`
  This is called in the build action after the pm files are copied and xs files are compiled.