### PR TITLE
Allow action after arguments

### DIFF
--- a/lib/Module/Build/Tiny.pm
+++ b/lib/Module/Build/Tiny.pm
@@ -176,10 +176,10 @@ sub get_arguments {
 }
 
 sub Build {
-	my $action = @ARGV && $ARGV[0] =~ /\A\w+\z/ ? shift @ARGV : 'build';
-	die "No such action '$action'\n" if not $actions{$action};
 	my($env, $bargv) = @{ decode_json(read_file('_build_params')) };
 	my %opt = get_arguments($env, $bargv, \@ARGV);
+	my $action = @ARGV && $ARGV[0] =~ /\A\w+\z/ ? shift @ARGV : 'build';
+	die "No such action '$action'\n" if not $actions{$action};
 	exit $actions{$action}->(%opt);
 }
 


### PR DESCRIPTION
Currently Module::Build::Tiny requires that the action comes before the arguments. This was strictly necessary before we deprecated `.modulebuildrc` files at the 2013 QAH in Lancaster. This ordering isn't needed anymore, but I'm not sure if we should allow other orders too.

I should emphasize, the Build.PL spec only specifies the [action options] order, not the [options actions] order, so Module::Build::Tiny isn't quite wrong, and if we change things here we should probably also update the spec.

Alternatively, we could issue a warning if anything is left in `@ARGV` after argument parsing.